### PR TITLE
Fix compile error with gnu-efi 3.0.8

### DIFF
--- a/Env.mk
+++ b/Env.mk
@@ -27,7 +27,7 @@ sbindir ?= $(prefix)/sbin
 includedir ?= $(prefix)/include
 
 gnuefi_libdir ?= $(libdir)
-GNU_EFI_VERSION ?= 305
+GNU_EFI_VERSION ?= 308
 
 LIB_GCC ?= $(shell $(CC) -print-libgcc-file-name)
 

--- a/Src/Efi/Include/BaseLibrary.h
+++ b/Src/Efi/Include/BaseLibrary.h
@@ -67,11 +67,13 @@ UINTN
 StrLen(CONST CHAR16 *String);
 #endif
 
+#if GNU_EFI_VERSION < 308
 CHAR16 *
 StrnCpy(CHAR16 *Destination, CONST CHAR16 *Source, UINTN MaxLength);
 
 UINTN
 StrnLen(CONST CHAR16 *String, UINTN MaxLength);
+#endif
 
 CHAR16 *
 StrStr(CONST CHAR16 *String, CONST CHAR16 *SearchString);

--- a/Src/Efi/Include/GnuEfi.h
+++ b/Src/Efi/Include/GnuEfi.h
@@ -74,6 +74,21 @@ StrCpy(
 	IN CONST CHAR16 *Src
 );
 
+#if GNU_EFI_VERSION >= 308
+VOID
+StrnCpy(
+	IN CHAR16 *Dest,
+	IN CONST CHAR16 *Src,
+	IN UINTN Len
+);
+
+UINTN
+StrnLen (
+	IN CONST CHAR16 *s1,
+	IN UINTN Len
+);
+#endif
+
 EFI_FILE_INFO *
 LibFileInfo(
 	IN EFI_FILE_HANDLE FHand

--- a/Src/Efi/Lib/BaseLibrary/Makefile
+++ b/Src/Efi/Lib/BaseLibrary/Makefile
@@ -9,7 +9,6 @@ OBJS_$(LIB_NAME) := \
 	MemDup.o \
 	StrDup.o \
 	StrAppend.o \
-	StrnCpy.o \
 	StrCaseCmp.o \
 	StrChr.o \
 	StrnChr.o \
@@ -17,8 +16,10 @@ OBJS_$(LIB_NAME) := \
 	StrStr.o \
 	StrrStr.o \
 	StrEndsWith.o \
-	StrnLen.o \
 	StrStr.o
+
+OBJS_$(LIB_NAME) += $(shell if [ $(GNU_EFI_VERSION) -lt 308 ]; \
+	then echo "StrnCpy.o StrnLen.o"; fi;)
 
 all: $(LIB_TARGET) Makefile
 

--- a/Src/Efi/Makefile
+++ b/Src/Efi/Makefile
@@ -40,7 +40,7 @@ LDFLAGS += -nostdlib -shared -Bsymbolic -L$(gnuefi_libdir) \
 	   -T $(EFI_LD_SCRIPT) $(gnuefi_libdir)/$(EFI_CRT0) \
 	   $(EXTRA_LDFLAGS)
 
-export CC AR CFLAGS LDFLAGS
+export CC AR CFLAGS LDFLAGS GNU_EFI_VERSION
 
 EFI_NAME := SELoader
 EFI_TARGET := $(EFI_NAME).efi


### PR DESCRIPTION
The commit 9485c65f6d28b71ff697849c1c8d47fd077ccd07 in gnu-efi 3.0.8
implements StrnCpy and StrnLen functions:

    commit 9485c65f6d28b71ff697849c1c8d47fd077ccd07
    Author: Peter Jones pjones@redhat.com
    Date: Tue Mar 13 15:20:28 2018 -0400

    gnu-efi: add some more common string functions.

    This adds bounded string helper functions:

    StrnLen()
    StrnCpy()
    StrnCat()
    StpnCpy()

    And the unbounded function StpCpy().

This would cause a seloader build error:

| /build/tmp-glibc/work/core2-64-wrs-linux/seloader/0.4.5+gitAUTOINC+9c2723afae-r0/recipe-sysroot/usr/lib64/libefi.a(str.o): In function StrnCpy': | /usr/src/debug/gnu-efi/3.0.8-r0/gnu-efi-3.0.8/lib/str.c:124: multiple definition of 'StrnCpy'
| /build/tmp-glibc/work/core2-64-wrs-linux/seloader/0.4.5+gitAUTOINC+9c2723afae-r0/git/Src/Efi/Lib/BaseLibrary/libBaseLibrary.a(StrnCpy.o):StrnCpy.c:(.text+0x0): first defined here
| /build/tmp-glibc/work/core2-64-wrs-linux/seloader/0.4.5+gitAUTOINC+9c2723afae-r0/git/Rules.mk:9: recipe for target 'SELoader.so' failed
| make[2]: *** [SELoader.so] Error 1

Bump the default GNU_EFI_VERSION to 308 and add conditional selection to
control the compilation. The user can specify GNU_EFI_VERSION=<ver>
explicitly if they want to build with old version gnu-efi.

Signed-off-by: Yi Zhao <yi.zhao@windriver.com>